### PR TITLE
feat : 프론트엔드 연동을 위해 cors allow 설정 추가

### DIFF
--- a/src/main/java/apptive/fin/global/config/SecurityConfig.java
+++ b/src/main/java/apptive/fin/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import apptive.fin.auth.BusinessAuthenticationEntryPoint;
 import apptive.fin.auth.JwtAuthFilter;
 import apptive.fin.auth.oauth.OAuth2SuccessHandler;
 import apptive.fin.auth.oauth.OAuth2UserService;
+import apptive.fin.global.properties.AppProperties;
 import apptive.fin.global.util.JwtUtil;
 import apptive.fin.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -28,9 +34,13 @@ public class SecurityConfig {
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final BusinessAuthenticationEntryPoint businessAuthenticationEntryPoint;
+    private final AppProperties appProperties;
+
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
@@ -53,6 +63,32 @@ public class SecurityConfig {
         return http.build();
     }
 
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 프론트엔드 도메인 명시 (로컬 개발용 및 실제 배포 도메인 추가)
+        configuration.setAllowedOrigins(List.of(
+                appProperties.frontend().url()
+        ));
+
+        // 허용할 HTTP 메서드 (OPTIONS는 Preflight 요청을 위해 필수)
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+        // 허용할 헤더
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // 프론트엔드에서 응답 헤더를 읽을 수 있도록 노출 (Set-Cookie 등)
+        configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
+
+        // 쿠키 및 인증 정보 전송 허용 (Refresh Token 쿠키를 위해 필수)
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {


### PR DESCRIPTION
# 변경점 👍
프론트엔드 주소에서 요청 시 CORS 허용을 위해, SecurityConfig에 CORS 허용 설정을 추가하였습니다.

# 테스트 💻
localhost:8080으로 백엔드 서버, localhost:5173으로 프론트엔드 개발 서버를 열고 요청 시도

# 스크린샷 🖼
<img width="1410" height="641" alt="image" src="https://github.com/user-attachments/assets/d2421584-e8e5-4e3e-bd46-f8e88bc0a67f" />


# 비고 ✏
 궁금한 점은 편하게 커멘트로 남겨 주세요!
 