### PR TITLE
fix: oauth2login에 failure handler 추가

### DIFF
--- a/src/main/java/apptive/fin/auth/oauth/OAuth2FailureHandler.java
+++ b/src/main/java/apptive/fin/auth/oauth/OAuth2FailureHandler.java
@@ -1,0 +1,33 @@
+package apptive.fin.auth.oauth;
+
+import apptive.fin.global.properties.AppProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final AppProperties appProperties;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+        throws IOException, ServletException
+    {
+        getRedirectStrategy().sendRedirect(
+                request, response,
+                appProperties.frontend().url() + appProperties.oAuth2().failureRedirectUrl()
+        );
+    }
+
+}

--- a/src/main/java/apptive/fin/global/config/SecurityConfig.java
+++ b/src/main/java/apptive/fin/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
            //                     .requestMatchers("/favicon.ico").permitAll()
-                                .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                                .requestMatchers("/oauth2/authorization/**", "/login/oauth2/**").permitAll()
                                 .requestMatchers("/auth/**").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/users").permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/apptive/fin/global/config/SecurityConfig.java
+++ b/src/main/java/apptive/fin/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package apptive.fin.global.config;
 
+import apptive.fin.auth.oauth.OAuth2FailureHandler;
 import apptive.fin.auth.security.BusinessAccessDeniedHandler;
 import apptive.fin.auth.security.BusinessAuthenticationEntryPoint;
 import apptive.fin.auth.security.JwtAuthFilter;
@@ -33,6 +34,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
     private final BusinessAuthenticationEntryPoint businessAuthenticationEntryPoint;
     private final BusinessAccessDeniedHandler businessAccessDeniedHandler;
     private final AppProperties appProperties;
@@ -54,6 +56,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
                 )
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(businessAuthenticationEntryPoint)

--- a/src/main/java/apptive/fin/global/properties/AppProperties.java
+++ b/src/main/java/apptive/fin/global/properties/AppProperties.java
@@ -14,7 +14,8 @@ public record AppProperties(
     ) {}
 
     public record OAuth2(
-            String successRedirectUrl
+            String successRedirectUrl,
+            String failureRedirectUrl
     ) {}
 
     public record Frontend(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,3 +54,4 @@ app:
     same-site: Lax
   oauth2:
     success-redirect-url: "/"
+    failure-redirect-url: "/login-error"


### PR DESCRIPTION
# 변경점 👍
- oauth2 로그인 과정에서 failure handler 추가
    - 로그인 실패 시 커스텀한 failure handler에서 처리되도록 수정
    - 로그인 실패 시 리다이렉트할 URL을 설정할 수 있도록 수정
 - oauth2 라우터 permitAll() 범위 축소
    -  로그인 시 필요한 URL들만 접근할 수 있도록 함
# 테스트 💻
- 단위 테스트
- 실행 후 로그인 플로우 정상 작동 확인

# 스크린샷 🖼
```java
.authorizeHttpRequests(auth -> auth
                .requestMatchers("/oauth2/authorization/**", "/login/oauth2/**").permitAll()  // 범위 축소
                .requestMatchers("/auth/**").permitAll()
                .requestMatchers(HttpMethod.POST, "/users").permitAll()
                .anyRequest().authenticated()
)
```

```java
.oauth2Login(oauth2 -> oauth2
        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
        .successHandler(oAuth2SuccessHandler)
        .failureHandler(oAuth2FailureHandler)  // failure handler 추가
)
```
 
# 비고 ✏
궁금한 점 있으시면 편하게 커맨트 남겨 주세요!
