### PR TITLE
fix : createdAt, updatedAt 등 타임존이 필요한 시간 데이터에 대한 컬럼 타입을 변경 (resolves #14)

### DIFF
--- a/src/main/java/apptive/fin/auth/entity/RefreshToken.java
+++ b/src/main/java/apptive/fin/auth/entity/RefreshToken.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "refresh_tokens",
@@ -32,7 +32,7 @@ public class RefreshToken extends BaseCreatedAtEntity {
     private String tokenHash;
 
     @Column(name = "expires_at", nullable = false)
-    private LocalDateTime expiresAt;
+    private Instant expiresAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -44,7 +44,7 @@ public class RefreshToken extends BaseCreatedAtEntity {
 
 
     @Builder
-    public RefreshToken(String tokenHash, LocalDateTime expiresAt, User user) {
+    public RefreshToken(String tokenHash, Instant expiresAt, User user) {
         this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
         this.user = user;
@@ -52,6 +52,6 @@ public class RefreshToken extends BaseCreatedAtEntity {
     }
 
     public boolean checkValidity() {
-        return isActive && expiresAt.isAfter(LocalDateTime.now());
+        return isActive && expiresAt.isAfter(Instant.now());
     }
 }

--- a/src/main/java/apptive/fin/auth/service/AuthService.java
+++ b/src/main/java/apptive/fin/auth/service/AuthService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Base64;
 
 @Service
@@ -70,7 +70,7 @@ public class AuthService {
 
         RefreshToken refreshToken = RefreshToken.builder()
                 .tokenHash(hashedRefreshToken)
-                .expiresAt(LocalDateTime.now().plusSeconds(jwtUtil.getRefreshExpiration()))
+                .expiresAt(Instant.now().plusSeconds(jwtUtil.getRefreshExpiration()))
                 .user(user)
                 .build();
         refreshTokenRepository.save(refreshToken);

--- a/src/main/java/apptive/fin/auth/util/JwtUtil.java
+++ b/src/main/java/apptive/fin/auth/util/JwtUtil.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 
@@ -42,12 +43,13 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(String userId, UserRole role, boolean requiredTermsAgreement) {
+        Instant now = Instant.now();
         return Jwts.builder()
                 .subject(userId)
                 .claim("role", role.name())
                 .claim("required_terms_agreement", requiredTermsAgreement)
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + jwtProperties.expiration() * 1000L))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(jwtProperties.expiration())))
                 .signWith(getKey())
                 .compact();
     }

--- a/src/main/java/apptive/fin/global/entity/BaseCreatedAtEntity.java
+++ b/src/main/java/apptive/fin/global/entity/BaseCreatedAtEntity.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -15,5 +15,5 @@ import java.time.LocalDateTime;
 public class BaseCreatedAtEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 }

--- a/src/main/java/apptive/fin/global/entity/BaseTimeEntity.java
+++ b/src/main/java/apptive/fin/global/entity/BaseTimeEntity.java
@@ -4,12 +4,10 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.Setter;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -17,5 +15,5 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity extends BaseCreatedAtEntity {
     @LastModifiedDate
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/apptive/fin/search/service/DynamicFormService.java
+++ b/src/main/java/apptive/fin/search/service/DynamicFormService.java
@@ -8,7 +8,8 @@ import apptive.fin.search.dto.SearchRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,13 +36,15 @@ public class DynamicFormService {
         }
 
         // 사용자가 입력한 가구원 수에 따라 중위소득 데이터를 반환한다
-        if (searchRequestDto.detailedOptions().householdSize() != null)
+        if (searchRequestDto.detailedOptions().householdSize() != null) {
+            int currentYear = Year.now(ZoneId.of("Asia/Seoul")).getValue();
             builder.medianIncomes(
                     medianIncomeService.getMedianIncomesDto(
-                            LocalDateTime.now().getYear(),
+                            currentYear,
                             searchRequestDto.detailedOptions().householdSize()
                     )
             );
+        }
 
         // 주거래 은행을 선택하면 은행의 우대금리 목록을 노출한다
         if (searchRequestDto.detailedOptions().mainBanks() != null &&

--- a/src/main/java/apptive/fin/term/dto/TermResponseDto.java
+++ b/src/main/java/apptive/fin/term/dto/TermResponseDto.java
@@ -1,7 +1,7 @@
 package apptive.fin.term.dto;
 
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record TermResponseDto (
     Long id,
@@ -9,7 +9,7 @@ public record TermResponseDto (
     String code,
     String title,
     String content,
-    LocalDateTime effectiveFrom,
+    Instant effectiveFrom,
     boolean isRequired,
     boolean agreed
 ) {

--- a/src/main/java/apptive/fin/term/entity/TermVersion.java
+++ b/src/main/java/apptive/fin/term/entity/TermVersion.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "term_versions", uniqueConstraints = {
@@ -46,5 +46,5 @@ public class TermVersion extends BaseCreatedAtEntity {
     private boolean isCurrent;
 
     @Column(name = "effective_from", nullable = false)
-    private LocalDateTime effectiveFrom;
+    private Instant effectiveFrom;
 }

--- a/src/main/java/apptive/fin/term/entity/UserTermAgreement.java
+++ b/src/main/java/apptive/fin/term/entity/UserTermAgreement.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "user_term_agreements", uniqueConstraints = {
@@ -37,11 +37,11 @@ public class UserTermAgreement extends BaseCreatedAtEntity {
     private boolean agreed;
 
     @Column(name = "agreed_at")
-    private LocalDateTime agreedAt = null;
+    private Instant agreedAt = null;
 
 
     @Builder
-    public UserTermAgreement(User user, TermVersion termVersion, boolean agreed, LocalDateTime agreedAt) {
+    public UserTermAgreement(User user, TermVersion termVersion, boolean agreed, Instant agreedAt) {
         this.user = user;
         this.termVersion = termVersion;
         this.agreed = agreed;
@@ -50,7 +50,7 @@ public class UserTermAgreement extends BaseCreatedAtEntity {
 
     public void agree(){
         this.agreed = true;
-        this.agreedAt = LocalDateTime.now();
+        this.agreedAt = Instant.now();
     }
 
     public void disagree() {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -92,7 +92,7 @@ INSERT INTO term_versions (
 **제7조 (준거법 및 재판관할)**
 본 약관과 관련하여 발생한 분쟁에 대하여는 대한민국 법을 준거법으로 하며, **Y-Fin.** 운영 주체 소재지의 관할 법원을 합의 관할 법원으로 합니다.$$,
           TRUE,
-          '2026-03-12 00:00:00'
+          '2026-03-12T00:00:00+09:00'
       ),
       (
           (SELECT id FROM terms WHERE code = 'PRIVACY_POLICY'),
@@ -134,7 +134,7 @@ INSERT INTO term_versions (
 - 성명: **이서빈**
 - 연락처: [팀 공용 메일]$$,
           TRUE,
-          '2026-03-12 00:00:00'
+          '2026-03-12T00:00:00+09:00'
       ),
       (
           (SELECT id FROM terms WHERE code = 'LOCATION_SERVICE_TERMS'),
@@ -157,7 +157,7 @@ INSERT INTO term_versions (
 1. **Y-Fin.**은 위치정보법에 따라 위치정보 이용·제공사실 확인자료를 시스템에 자동으로 기록하며, 해당 자료를 **6개월 이상 보관**합니다.
 2. 이용 목적 달성 시 재생이 불가능한 방법으로 즉시 파기합니다.$$,
           TRUE,
-          '2026-03-12 00:00:00'
+          '2026-03-12T00:00:00+09:00'
       ),
       (
           (SELECT id FROM terms WHERE code = 'MARKETING_TERMS'),
@@ -179,7 +179,7 @@ INSERT INTO term_versions (
 - **본 동의는 선택 사항이며, 거부하더라도 기본 시뮬레이션 서비스 이용에는 제한이 없습니다.**
 - 동의 후에도 마이페이지 설정을 통해 언제든지 수신 거부 및 동의 철회가 가능합니다.$$,
           TRUE,
-          '2026-03-12 00:00:00'
+          '2026-03-12T00:00:00+09:00'
       );
 
 INSERT INTO category (name) VALUES

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,8 +15,8 @@ CREATE TABLE users (
                        provider VARCHAR(50) NOT NULL,
                        provider_id VARCHAR(255) NOT NULL,
                        user_role VARCHAR(50) NOT NULL DEFAULT 'BEFORE_AGREED',
-                       created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                       updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                       created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                       updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                        CONSTRAINT uq_users_provider_account UNIQUE (provider, provider_id)
 );
 
@@ -25,8 +25,8 @@ CREATE TABLE refresh_tokens (
                                 user_id BIGINT NOT NULL,
                                 token_hash VARCHAR(255) NOT NULL,
                                 is_active BOOLEAN NOT NULL,
-                                expires_at TIMESTAMP NOT NULL,
-                                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                                created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                                 CONSTRAINT fk_refresh_tokens_user
                                     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
                                 CONSTRAINT uq_refresh_tokens_token_hash UNIQUE (token_hash)
@@ -49,7 +49,7 @@ CREATE TABLE terms (
        id BIGSERIAL PRIMARY KEY,
        code VARCHAR(100) NOT NULL UNIQUE,
        is_required BOOLEAN NOT NULL,
-       created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+       created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE term_versions(
@@ -60,8 +60,8 @@ CREATE TABLE term_versions(
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
     is_current BOOLEAN NOT NULL DEFAULT TRUE,
-    effective_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 효력이 생기는 날짜
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    effective_from TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 효력이 생기는 날짜
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
 
     CONSTRAINT fk_term_version_term
@@ -80,8 +80,8 @@ CREATE TABLE user_term_agreements (
     user_id BIGINT NOT NULL,
     term_version_id BIGINT NOT NULL,
     agreed BOOLEAN NOT NULL,
-    agreed_at TIMESTAMP NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    agreed_at TIMESTAMP WITH TIME ZONE NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_user_term_agreement_user
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,

--- a/src/test/java/apptive/fin/auth/AuthServiceTest.java
+++ b/src/test/java/apptive/fin/auth/AuthServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -50,7 +50,7 @@ class AuthServiceTest {
     void 리프레시_토큰을_발급하면_해시를_저장하고_raw_토큰을_반환한다() {
         User user = createUser(1L, UserRole.BASIC_ACCESS);
         byte[] rawRefreshToken = new byte[]{1, 2, 3, 4};
-        LocalDateTime beforeCall = LocalDateTime.now();
+        Instant beforeCall = Instant.now();
 
         when(jwtUtil.generateRefreshToken()).thenReturn(rawRefreshToken);
         when(jwtUtil.hashToken(rawRefreshToken)).thenReturn("hashed-token");
@@ -66,7 +66,7 @@ class AuthServiceTest {
         assertThat(savedToken.getUser()).isSameAs(user);
         assertThat(savedToken.isActive()).isTrue();
         assertThat(savedToken.getExpiresAt())
-                .isBetween(beforeCall.plusSeconds(120), LocalDateTime.now().plusSeconds(120));
+                .isBetween(beforeCall.plusSeconds(120), Instant.now().plusSeconds(120));
     }
 
     @Test
@@ -77,7 +77,7 @@ class AuthServiceTest {
         User user = createUser(1L, UserRole.ADMIN);
         RefreshToken storedToken = RefreshToken.builder()
                 .tokenHash("old-hash")
-                .expiresAt(LocalDateTime.now().plusMinutes(5))
+                .expiresAt(Instant.now().plusSeconds(300))
                 .user(user)
                 .build();
 
@@ -117,7 +117,7 @@ class AuthServiceTest {
         String encodedToken = Base64.getEncoder().encodeToString(rawToken);
         RefreshToken inactiveToken = RefreshToken.builder()
                 .tokenHash("inactive-hash")
-                .expiresAt(LocalDateTime.now().plusMinutes(5))
+                .expiresAt(Instant.now().plusSeconds(300))
                 .user(createUser(1L, UserRole.BASIC_ACCESS))
                 .build();
         ReflectionTestUtils.setField(inactiveToken, "isActive", false);
@@ -134,7 +134,7 @@ class AuthServiceTest {
         String encodedToken = Base64.getEncoder().encodeToString(rawToken);
         RefreshToken expiredToken = RefreshToken.builder()
                 .tokenHash("expired-hash")
-                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                .expiresAt(Instant.now().minusSeconds(60))
                 .user(createUser(1L, UserRole.BASIC_ACCESS))
                 .build();
 

--- a/src/test/java/apptive/fin/auth/RefreshTokenTest.java
+++ b/src/test/java/apptive/fin/auth/RefreshTokenTest.java
@@ -6,7 +6,7 @@ import apptive.fin.user.UserRole;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,34 +14,34 @@ class RefreshTokenTest {
 
     @Test
     void 새로_생성한_리프레시_토큰은_기본적으로_활성_상태다() {
-        RefreshToken refreshToken = createRefreshToken(LocalDateTime.now().plusMinutes(5));
+        RefreshToken refreshToken = createRefreshToken(Instant.now().plusSeconds(300));
 
         assertThat(refreshToken.isActive()).isTrue();
     }
 
     @Test
     void 활성_상태이면서_만료되지_않은_토큰은_유효하다() {
-        RefreshToken refreshToken = createRefreshToken(LocalDateTime.now().plusMinutes(5));
+        RefreshToken refreshToken = createRefreshToken(Instant.now().plusSeconds(300));
 
         assertThat(refreshToken.checkValidity()).isTrue();
     }
 
     @Test
     void 만료된_토큰은_유효하지_않다() {
-        RefreshToken refreshToken = createRefreshToken(LocalDateTime.now().minusMinutes(1));
+        RefreshToken refreshToken = createRefreshToken(Instant.now().minusSeconds(60));
 
         assertThat(refreshToken.checkValidity()).isFalse();
     }
 
     @Test
     void 비활성_상태인_토큰은_유효하지_않다() {
-        RefreshToken refreshToken = createRefreshToken(LocalDateTime.now().plusMinutes(5));
+        RefreshToken refreshToken = createRefreshToken(Instant.now().plusSeconds(300));
         ReflectionTestUtils.setField(refreshToken, "isActive", false);
 
         assertThat(refreshToken.checkValidity()).isFalse();
     }
 
-    private RefreshToken createRefreshToken(LocalDateTime expiresAt) {
+    private RefreshToken createRefreshToken(Instant expiresAt) {
         return RefreshToken.builder()
                 .tokenHash("hashed-token")
                 .expiresAt(expiresAt)

--- a/src/test/java/apptive/fin/search/DynamicFormServiceTest.java
+++ b/src/test/java/apptive/fin/search/DynamicFormServiceTest.java
@@ -15,7 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -85,7 +86,7 @@ class DynamicFormServiceTest {
 
     @Test
     void 가구원수가_있으면_현재연도와_가구원수로_중위소득을_조회한다() {
-        int currentYear = LocalDateTime.now().getYear();
+        int currentYear = Year.now(ZoneId.of("Asia/Seoul")).getValue();
         MedianIncomesDto medianIncomesDto = createMedianIncomesDto(currentYear, 3);
         SearchRequestDto request = createRequest(List.of(), 3, List.of());
 
@@ -180,7 +181,7 @@ class DynamicFormServiceTest {
 
     @Test
     void 복합조건이_들어오면_여러_분기를_동시에_반영한다() {
-        int currentYear = LocalDateTime.now().getYear();
+        int currentYear = Year.now(ZoneId.of("Asia/Seoul")).getValue();
         MedianIncomesDto medianIncomesDto = createMedianIncomesDto(currentYear, 3);
         SearchRequestDto request = createRequest(
                 List.of(

--- a/src/test/java/apptive/fin/term/TermServiceTest.java
+++ b/src/test/java/apptive/fin/term/TermServiceTest.java
@@ -24,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.BeanUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
@@ -71,7 +71,7 @@ class TermServiceTest {
                         "SERVICE_TERMS",
                         "서비스 이용약관 v2.0",
                         "content",
-                        LocalDateTime.now(),
+                        Instant.now(),
                         true,
                         false
                 )
@@ -91,7 +91,7 @@ class TermServiceTest {
                         "SERVICE_TERMS",
                         "서비스 이용약관 v1.0",
                         "content",
-                        LocalDateTime.now(),
+                        Instant.now(),
                         true,
                         true
                 )
@@ -295,7 +295,7 @@ class TermServiceTest {
         ReflectionTestUtils.setField(termVersion, "title", term.getCode() + " v" + majorVersion + "." + minorVersion);
         ReflectionTestUtils.setField(termVersion, "content", "content");
         ReflectionTestUtils.setField(termVersion, "isCurrent", current);
-        ReflectionTestUtils.setField(termVersion, "effectiveFrom", LocalDateTime.of(2026, 3, 12, 0, 0));
+        ReflectionTestUtils.setField(termVersion, "effectiveFrom", Instant.parse("2026-03-11T15:00:00Z"));
         return termVersion;
     }
 }


### PR DESCRIPTION
# 변경점 👍
- createdAt, updatedAt 타입 Instant로 변경

- RefreshToken.expiresAt, 약관 동의 및 효력 시간 Instant로 변경

- JwtUtil의 현재 시간 계산을 Instant.now() 기반으로 변경

- DynamicFormService의 현재 연도 계산을 Year.now(ZoneId.of("Asia/Seoul"))로 변경

- 스키마 시간 컬럼 TIMESTAMP WITH TIME ZONE로 맞춤. 초기 데이터 약관 타임존 포함 시간으로 변경 

# 테스트 💻
단위 테스트 및 Postman 및 데이터베이스 확인을 통한 테스트

# 스크린샷 🖼
회원가입 시 created_at, updated_at 등이 UTC 기준으로 저장됨
<img width="1131" height="335" alt="image" src="https://github.com/user-attachments/assets/c42acef1-f044-48c9-b663-c2a2560bf16a" />

약관 목록 요청 시 발효시점 UTC 기준으로 전달(타임존 포함)
<img width="585" height="216" alt="image" src="https://github.com/user-attachments/assets/bc1be2c8-81c4-48d6-8df1-aa69f8343984" />

jwt 토큰 유효시간 10분(600초) 정상 작동
<img width="372" height="183" alt="image" src="https://github.com/user-attachments/assets/e854ebed-204d-4488-aa7a-cb65ec76edc4" />

DynamicFormService 동적 폼 중위소득 연도 정상 작동
<img width="715" height="455" alt="image" src="https://github.com/user-attachments/assets/869defda-1fa5-4f72-8119-ffa0b90f4f14" />


 
# 비고 ✏
궁금한 점 있으시면 편하게 커맨트 남겨 주세요!

